### PR TITLE
Update Span.swift

### DIFF
--- a/Sources/OpenTelemetryApi/Trace/Span.swift
+++ b/Sources/OpenTelemetryApi/Trace/Span.swift
@@ -74,7 +74,7 @@ public extension Span {
         hasher.combine(context.spanId)
     }
 
-    static func == (lhs: Span, rhs: Span) -> Bool {
+    static func == (lhs: Self, rhs: Self) -> Bool {
         return lhs.context.spanId == rhs.context.spanId
     }
 }


### PR DESCRIPTION
Porting changes from https://github.com/DataDog/opentelemetry-swift-packages/blob/main/Sources/OpenTelemetryApi/Trace/Span.swift#L116 to fix the compilation issue in latest XCode